### PR TITLE
adding unique constraint (user_id + project_id) in Alocation table

### DIFF
--- a/src/main/java/ie3/i_e3_backend/domain/Alocation.java
+++ b/src/main/java/ie3/i_e3_backend/domain/Alocation.java
@@ -5,7 +5,7 @@ import jakarta.persistence.*;
 
 
 @Entity
-@Table(name = "Alocations")
+@Table(name = "Alocations", uniqueConstraints = {@UniqueConstraint(columnNames = {"user_id", "project_id"})})
 public class Alocation {
 
     @Id

--- a/src/main/java/ie3/i_e3_backend/model/DTOs/AlocationDTO.java
+++ b/src/main/java/ie3/i_e3_backend/model/DTOs/AlocationDTO.java
@@ -16,10 +16,8 @@ public class AlocationDTO {
     @NotNull
     private Role employeeRole;
 
-    @AlocationUserUnique
     private Long user;
 
-    @AlocationProjectUnique
     private Long project;
 
     public Long getId() {


### PR DESCRIPTION
Notei que o Dto de alocação barrava a repetição do user ou do projeto (só um deles, não a combinação dos dois), então removi os unique e adicionei constraint na table pra que só a combinação dos dois não se repita.